### PR TITLE
v0.2.0

### DIFF
--- a/internal/cache/database/schema.go
+++ b/internal/cache/database/schema.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const schemaVersion = 4
+const schemaVersion = 5
 
 func initSchema(db *sql.DB) error {
 	// Check schema version

--- a/internal/cache/store/sqlite/scanner.go
+++ b/internal/cache/store/sqlite/scanner.go
@@ -52,9 +52,11 @@ func scanDirectory(root string) ([]*FileInfo, error) {
 			return err
 		}
 		// skip hidden directories
-		if info.IsDir() && strings.HasPrefix(filepath.Base(path), ".") {
-			log.Printf("Ignoring hidden directory %s during scan.", root)
-			return filepath.SkipDir
+		if info.IsDir() {
+			if strings.HasPrefix(filepath.Base(path), ".") {
+				log.Printf("Ignoring hidden directory %s during scan.", root)
+				return filepath.SkipDir
+			}
 		} else {
 			fileInfo, err := scanFile(path)
 			if err != nil {

--- a/internal/cache/store/sqlite/scanner.go
+++ b/internal/cache/store/sqlite/scanner.go
@@ -47,28 +47,14 @@ func scanFile(path string) (*FileInfo, error) {
 func scanDirectory(root string) ([]*FileInfo, error) {
 	var files []*FileInfo
 
-	// check for empty path
-	if root == "" {
-		return nil, nil
-	}
-
-	// check if directory is hidden
-	if strings.HasPrefix(filepath.Base(root), ".") {
-		log.Printf("Ignoring hidden directory %s during scan.", root)
-		return nil, nil
-	}
-
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
-			subfiles, err := scanDirectory(path)
-			if err != nil {
-				log.Printf("Error scanning sub directory %s: %v", path, err)
-			} else {
-				files = append(files, subfiles...)
-			}
+		// skip hidden directories
+		if info.IsDir() && strings.HasPrefix(filepath.Base(path), ".") {
+			log.Printf("Ignoring hidden directory %s during scan.", root)
+			return filepath.SkipDir
 		} else {
 			fileInfo, err := scanFile(path)
 			if err != nil {

--- a/internal/cache/store/sqlite/scanner.go
+++ b/internal/cache/store/sqlite/scanner.go
@@ -54,7 +54,7 @@ func scanDirectory(root string) ([]*FileInfo, error) {
 		// skip hidden directories
 		if info.IsDir() {
 			if strings.HasPrefix(filepath.Base(path), ".") {
-				log.Printf("Ignoring hidden directory %s during scan.", root)
+				log.Printf("Ignoring hidden directory %s during scan.", path)
 				return filepath.SkipDir
 			}
 		} else {


### PR DESCRIPTION
Some improvements to the file-tracking logic:
- track non-typst files in internal database and bibliography
- only add files present on disk to bibliography
- ignore hidden directories (.git, .zeta, etc ...) during scan