### PR TITLE
Version Number + Darwin Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            nix-system: x86_64-linux
+          - runs-on: ubuntu-24.04-arm
+            nix-system: aarch64-linux
+
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Flake check
+        run: nix flake check
+
+      - name: Build zeta
+        run: nix build .#packages.${{ matrix.nix-system }}.zeta -L

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,43 +9,62 @@ permissions:
   contents: write
 
 jobs:
-  build-and-release:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+            nix-system: x86_64-linux
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+            nix-system: aarch64-linux
+
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Nix
-        uses: cachix/install-nix-action@v26
+        uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
 
-      # - name: Set up QEMU for ARM64 emulation
-      #   uses: docker/setup-qemu-action@v3
-      #   with:
-      #     platforms: linux/arm64
+      - name: Build binary
+        run: nix build .#packages.${{ matrix.nix-system }}.zeta
 
-      - name: Build Linux x86_64 binary
-        run: nix build .#packages.x86_64-linux.zeta
-
-      # - name: Build Linux aarch64 binary
-      #   run: nix build .#packages.aarch64-linux.zeta
-
-      - name: Prepare binaries
+      - name: Stage artifact
         run: |
-          mkdir dist
-          cp result/bin/zeta dist/zeta-linux-amd64
-          # cp result-2/bin/zeta dist/zeta-linux-arm64
-          chmod +x dist/* || true
+          mkdir -p dist
+          cp result/bin/zeta dist/zeta-linux-${{ matrix.arch }}
+          chmod +x dist/zeta-linux-${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: zeta-linux-${{ matrix.arch }}
+          path: dist/zeta-linux-${{ matrix.arch }}
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/zeta-linux-amd64
-            # dist/zeta-linux-arm64
+            dist/zeta-linux-arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/_example/demo.lua
+++ b/_example/demo.lua
@@ -56,9 +56,9 @@ vim.api.nvim_create_autocmd({ "BufReadPost", "BufNewFile" }, {
   callback = function()
     vim.lsp.start({
       name = "zeta",
-      cmd  = { "/tmp/zeta-testing/zeta", "--logfile=/tmp/zeta.log"},
+      cmd  = { "zeta" },
       filetypes = { "typst" },
-      root_dir  = "/tmp/zeta-demo-notes",
+      root_dir  = vim.fn.getcwd(),
       capabilities = vim.lsp.protocol.make_client_capabilities(),
       single_file_support = true,
       init_options = init_options,

--- a/_example/demo.txt
+++ b/_example/demo.txt
@@ -4,7 +4,7 @@ Zeta is a language server that I created to navigate my mathematical notes more 
 
 The language server detects *metadata* and *links* to other notes via configurable `treesitter-queries`.a
 
-Let's look at an example!`.a
+Let's look at an example!a
 
 :e c5a546.typ
 i= Every Vectorspace has a Basis <Theorem>
@@ -34,8 +34,6 @@ Tip: This pairs very nicely with Telescope's `Telescope lsp_workspace_symbols` c
 
 :lua vim.lsp.buf.workspace_symbol()
 
-
-
 :cclose
 Go
 Finally there is the graph view. It is accessed via a `worskpace command`.
@@ -43,5 +41,3 @@ The graph updates in real-time as you type.a
 :ZetaGraph
 o#link("")[]3hiI am typing this reference as we are viewing the graph
 oI will now show you what the graph may look like when you have more notes.
-
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1745377448,
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,133 +3,150 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, ... }@inputs:
-  let
-    systems = [ "x86_64-linux" "aarch64-linux" ];
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
 
-    # overlay dependencies
-    overlay = final: prev: {
-      force-graph = prev.fetchurl {
-        url = "https://cdn.jsdelivr.net/npm/force-graph@1.49.5/dist/force-graph.min.js";
-        sha256 = "sha256-x3jy78zXsY6aQDD1PYHTGfF5qKuPvG8QAB3GyQTSA6E=";
-      };
-      tree-sitter-typst = prev.fetchFromGitHub {
-        owner = "uben0";
-        repo = "tree-sitter-typst";
-        rev = "46cf4ded12ee974a70bf8457263b67ad7ee0379d";
-        sha256 = "sha256-s/9R3DKA6dix6BkU4mGXaVggE4bnzOyu20T1wuqHQxk=";
-      };
-    };
+        force-graph = pkgs.fetchurl {
+          url = "https://cdn.jsdelivr.net/npm/force-graph@1.49.5/dist/force-graph.min.js";
+          sha256 = "sha256-x3jy78zXsY6aQDD1PYHTGfF5qKuPvG8QAB3GyQTSA6E=";
+        };
 
-    # Helper to import nixpkgs with our overlay
-    forAllSystems = f:
-      nixpkgs.lib.genAttrs systems (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ overlay ];
+        tree-sitter-typst-src = pkgs.tree-sitter-grammars.tree-sitter-typst.src;
+      in {
+        packages = rec {
+          zeta = pkgs.buildGoModule rec {
+            pname = "zeta";
+            version = "0.3.5";
+
+            src = pkgs.lib.cleanSourceWith {
+              src = ./.;
+              filter = path: _type: let
+                base = baseNameOf path;
+              in
+                !(builtins.elem base ["result" "_example"]);
+            };
+
+            nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [
+              pkgs.gcc
+            ];
+
+            buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [
+              pkgs.glibc.static
+            ];
+
+            env.CGO_ENABLED = "1";
+
+            ldflags =
+              [
+                "-s"
+                "-w"
+                "-X main.Version=v${version}"
+              ]
+              ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+                "-linkmode external"
+                "-extldflags -static"
+              ];
+
+            vendorHash = "sha256-6muGhy8MNOC5EkFtoGCQ3QgEMKYsg0Y/aG2HBJsJqnM=";
+            doCheck = false;
+            enableParallelBuilding = true;
+
+            postPatch = ''
+              mkdir -p external/_vendor
+              rm -rf .gitignore
+              cp -r ${tree-sitter-typst-src} external/_vendor/tree-sitter-typst
+              cp -r ${force-graph} external/_vendor/force-graph.js
+            '';
           };
-        in f { inherit pkgs system; }
-      );
-  in {
-    packages = forAllSystems ({ pkgs, system }: rec {
-      zeta = pkgs.buildGoModule rec {
-        pname   = "zeta";
-        version = "0.3.5";
-        src     = ./.;
 
-        buildInputs = [
-          pkgs.go
-          pkgs.gcc
-          pkgs.glibc.static
-          pkgs.glibcLocales
-        ];
+          default = zeta;
+        };
 
-        env.CGO_ENABLED = "1";
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.zeta}/bin/zeta";
+          };
+        };
 
-        ldflags = [
-          "-s" "-w"
-          "-linkmode external"
-          "-extldflags -static"
-          "-X main.Version=v${version}"
-        ];
+        formatter = pkgs.alejandra;
 
-        vendorHash = "sha256-6muGhy8MNOC5EkFtoGCQ3QgEMKYsg0Y/aG2HBJsJqnM=";
-        doCheck    = false;
+        devShells = let
+          zetaPkg = self.packages.${system}.zeta;
 
-        patchPhase = ''
-          mkdir -p external/_vendor
-          rm -rf .gitignore
-          cp -r ${pkgs.tree-sitter-typst} external/_vendor/tree-sitter-typst
-          cp -r ${pkgs.force-graph}   external/_vendor/force-graph.js
-        '';
-      };
+          mkTestbed = ''
+            testdir="$(mktemp -d -t zeta-testing.XXXXXX)"
+            notesdir="$(mktemp -d -t zeta-test-notes.XXXXXX)"
+            touch $notesdir/test.typ
+            trap 'rm -rf "$testdir" "$notesdir"' EXIT
+          '';
 
-      default = zeta;
-    });
+          debugCmd = pkgs.writeShellScriptBin "debug" ''
+            ${mkTestbed}
+            go build -o "$testdir/zeta" -gcflags=all=-N . || exit
+            PATH="$testdir:$PATH"
+            exec ${pkgs.neovim}/bin/nvim -u ${./_example/init.lua} "$notesdir/test.typ"
+          '';
 
-devShells = forAllSystems ({ pkgs, system }: let
-      debugCmd = pkgs.writeShellScriptBin "debug" ''
-        rm -rf /tmp/zeta-testing/*
-        mkdir -p /tmp/zeta-test-notes
-        mkdir -p /tmp/zeta-testing
-        go build -o /tmp/zeta-testing/zeta -gcflags=all=-N . || exit
-        PATH="/tmp/zeta-testing:$PATH"
-        exec ${pkgs.neovim}/bin/nvim -u ${./_example/init.lua} /tmp/zeta-test-notes/test.typ
-      '';
+          debugReleaseCmd = pkgs.writeShellScriptBin "debugRelease" ''
+            ${mkTestbed}
+            PATH="${zetaPkg}/bin:$PATH"
+            exec ${pkgs.neovim}/bin/nvim -u ${./_example/init.lua} "$notesdir/test.typ"
+          '';
 
-      debugReleaseCmd = pkgs.writeShellScriptBin "debugRelease" ''
-        rm -rf /tmp/zeta-testing/*
-        mkdir -p /tmp/zeta-test-notes
-        mkdir -p /tmp/zeta-testing
-        nix build .#zeta || exit
-        cp result/bin/zeta /tmp/zeta-testing/zeta
-        PATH="/tmp/zeta-testing:$PATH"
-        exec ${pkgs.neovim}/bin/nvim -u ${./_example/init.lua} /tmp/zeta-test-notes/test.typ
-      '';
+          vendorCmd = pkgs.writeShellScriptBin "vendor" ''
+            echo "Populating _vendor directory..."
+            rm -rf external/_vendor
+            mkdir -p external/_vendor
+            cp -r --no-preserve=mode,ownership ${tree-sitter-typst-src} external/_vendor/tree-sitter-typst
+            cp -r --no-preserve=mode,ownership ${force-graph} external/_vendor/force-graph.js
+            echo "_vendor directory is now up to date."
+          '';
 
-      vendorCmd = pkgs.writeShellScriptBin "vendor" ''
-        echo "Populating _vendor directory..."
-        rm -rf external/_vendor
-        mkdir -p external/_vendor
-        cp -r --no-preserve=mode,ownership ${pkgs.tree-sitter-typst} external/_vendor/tree-sitter-typst
-        cp -r --no-preserve=mode,ownership ${pkgs.force-graph} external/_vendor/force-graph.js
-        echo "_vendor directory is now up to date."
-      '';
+          demo = pkgs.writeShellScriptBin "demo" ''
+            set -e
+            root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+            workdir="$(mktemp -d -t zeta-demo.XXXXXX)"
+            trap 'rm -rf "$workdir"' EXIT
 
-      demo = pkgs.writeShellScriptBin "demo" ''
-        rm -rf /tmp/zeta-demo-notes
-        mkdir -p /tmp/zeta-demo-notes
-        cd /tmp/zeta-demo-notes
+            go build -C "$root" -o "$workdir/zeta" .
 
-        pv -qL 20 ${./_example/demo.txt} \
-          | script -q -c \
-          "stty rows $(tput lines) cols $(tput cols); \
-          nvim -u ${./_example/demo.lua}" \
-          /dev/null
-      '';
-    in {
-      default = pkgs.mkShell {
-        shellHook = ''
-          echo "== Welcome to zeta dev shell =="
-        '';
-        buildInputs = [
-          pkgs.go
-          pkgs.gopls
-          pkgs.gofumpt
-          pkgs.gotools
-          pkgs.golines
-          pkgs.typst
-          pkgs.tinymist
-          pkgs.pv
-          debugCmd
-          debugReleaseCmd
-          vendorCmd
-          demo
-        ];
-      };
-    });
-  };
+            cd "$workdir"
+            export PATH="$workdir:$PATH"
+            ${pkgs.pv}/bin/pv -qL 20 "$root/_example/demo.txt" \
+              | ${pkgs.expect}/bin/unbuffer -p ${pkgs.neovim}/bin/nvim -u "$root/_example/demo.lua"
+          '';
+        in {
+          default = pkgs.mkShell {
+            shellHook = ''
+              echo "== Welcome to zeta dev shell =="
+            '';
+            packages = [
+              pkgs.go
+              pkgs.gopls
+              pkgs.gofumpt
+              pkgs.gotools
+              pkgs.golines
+              pkgs.typst
+              pkgs.tinymist
+              pkgs.pv
+              debugCmd
+              debugReleaseCmd
+              vendorCmd
+              demo
+            ];
+          };
+        };
+      }
+    );
 }

--- a/internal/server/lifecycle_handlers.go
+++ b/internal/server/lifecycle_handlers.go
@@ -146,6 +146,10 @@ func (s *Server) initialize(
 
 	return protocol.InitializeResult{
 		Capabilities: capabilities,
+		ServerInfo: &protocol.InitializeResultServerInfo{
+			Name:    "zeta",
+			Version: &s.version,
+		},
 	}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,10 +15,11 @@ type Server struct {
 	manager   *manager.DocumentManager
 	graphAddr string
 	config    config.Config
+	version   string
 }
 
-func NewServer() (*server.Server, error) {
-	ls := &Server{}
+func NewServer(version string) (*server.Server, error) {
+	ls := &Server{version: version}
 	ls.handler = &protocol.Handler{
 		Initialize:              ls.initialize,
 		Initialized:             ls.initialized,

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 		log.SetOutput(os.Stdout)
 	}
 
-	serverInstance, err := server.NewServer()
+	serverInstance, err := server.NewServer(Version)
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"runtime"
@@ -47,8 +48,7 @@ func main() {
 		log.SetFlags(log.Ldate | log.Ltime | log.Llongfile)
 		log.Println("Starting zeta LSP server...")
 	} else {
-		// discard logs by default
-		log.SetOutput(os.Stdout)
+		log.SetOutput(io.Discard)
 	}
 
 	serverInstance, err := server.NewServer(Version)


### PR DESCRIPTION
## Description

This PR does a bunch of small changes to the nix flake, and less to `zeta` itself, GitHub Actions, and the demo. 
A fair amount of the changes (like using `flake-utils` and `alejandra`) are arbitrary, so feel free to change/remove them if you don't like.

## Changes

- Flake rewrite (813a208):
  - Swap to `numtide/flake-utils` for less boilerplate
  - Use `tree-sitter-typst` from nixpkgs
  - Filtered `result` and `_example` from src to improve caching
  - Remove unnecessary build inputs, mark `gcc` and `glibc` as linux only 
  - Move `gcc` to `nativeBuildInputs`
  - Ignore static linking for darwin (in `ldflags`)
  - Enabled parallel building
  - Move `patchPhase` to `postPhase`
  - Added `apps` so `nix run` runs `zeta`
  - Added `alejandra` as a nix formatter so `nix fmt` works 
  - Use `mktemp` and `trap` for tmp dirs
  - Rebuild in demo so we get package build off HEAD
  - Tried to make demo work on darwin by swapping to `unbuffer` (hopefully still works the same on linux)
  - Changed `buildInputs` in devShell to `packages`
  
- `zeta` changes:
  - Added `ServerInfo` to `InitializeResult`, so Vim can properly display version num (i.e.`:checkhealth`) (b97719f)
  - Pass `main.Version` to`NewServer` so our version number matches the build arg (b97719f)
  - Swap log output from `os.Stdout` to `io.Discard` so logs are actually discarded (ea6c027)
 
- GitHub Actions (68c48ca):
  - Added aarch64-linux to release action
  - Added CI action to check build works on x86_64-linux and aarch64-linux
  - Updated versions for actions

- Removed tmp paths from neovim config in the `demo.lua` + tiny grammar change in `demo.txt` (ccd6b7a)

## Testing

- Built locally and ran all commands to test aarch64-darwin
- Ran build + commands in Docker to try and test aarch64-linux